### PR TITLE
Improve names of binary operators in json

### DIFF
--- a/src/Cabal2JSON.hs
+++ b/src/Cabal2JSON.hs
@@ -378,11 +378,11 @@ instance HasCodec (Condition ConfVar) where
   codec =
     named "Condition" $
       dimapCodec f g $
-        eitherCodec (object "var" $ requiredField' "v") $
+        eitherCodec (object "var" $ requiredField' "variable") $
           eitherCodec (object "lit" $ requiredField' "bool") $
-            eitherCodec (object "cnot" $ requiredField' "cond") $
-              eitherCodec (object "cor" $ (,) <$> requiredField' "cond1" .= fst <*> requiredField' "cond2" .= snd) $
-                object "cand" $ (,) <$> requiredField' "cond12" .= fst <*> requiredField' "cond22" .= snd
+            eitherCodec (object "not" $ requiredField' "cond_not") $
+              eitherCodec (object "or" $ (,) <$> requiredField' "cond_or_1" .= fst <*> requiredField' "cond_or_2" .= snd) $
+                object "and" $ (,) <$> requiredField' "cond_and_1" .= fst <*> requiredField' "cond_and_2" .= snd
     where
       f = \case
         Left c -> Var c

--- a/test_resources/schemas/generic-package-description.txt
+++ b/test_resources/schemas/generic-package-description.txt
@@ -1941,7 +1941,7 @@
         [36mdef: Condition[m
         # [32many of[m
         [ # var
-          [37mv[m: # [31mrequired[m
+          [37mvariable[m: # [31mrequired[m
             # ConfVar
             # [32many of[m
             [ [37mos[m: # [31mrequired[m
@@ -2004,18 +2004,18 @@
         , # lit
           [37mbool[m: # [31mrequired[m
             [33m<boolean>[m
-        , # cnot
-          [37mcond[m: # [31mrequired[m
+        , # not
+          [37mcond_not[m: # [31mrequired[m
             [36mref: Condition[m
-        , # cor
-          [37mcond1[m: # [31mrequired[m
+        , # or
+          [37mcond_or_1[m: # [31mrequired[m
             [36mref: Condition[m
-          [37mcond2[m: # [31mrequired[m
+          [37mcond_or_2[m: # [31mrequired[m
             [36mref: Condition[m
-        , # cand
-          [37mcond12[m: # [31mrequired[m
+        , # and
+          [37mcond_and_1[m: # [31mrequired[m
             [36mref: Condition[m
-          [37mcond22[m: # [31mrequired[m
+          [37mcond_and_2[m: # [31mrequired[m
             [36mref: Condition[m
         ]
       [37mcondBranchIfTrue[m: # [31mrequired[m


### PR DESCRIPTION
This MR improves the names of the conditional binary operators.

```
if flag(pkg-config) && !impl(ghcjs) && !os(ghcjs)
    -- NB: pkg-config is available on windows as well when using msys2
    pkgconfig-depends: zlib
```

Now results in 

```
{
  "cond_and_1": {
    "cond_and_1": {
      "variable": {
        "flag": "pkg-config"
      }
    },
    "cond_and_2": {
      "cond_not": {
        "variable": {
          "compiler": "GHCJS",
          "version": "-any"
        }
      }
    }
  },
  "cond_and_2": {
    "cond_not": {
      "variable": {
        "os": "Ghcjs"
      }
    }
  }
}
```
