### PR TITLE
Add more systems to `supportedSystems`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,14 @@
       ];
     });
 
-    packages = forAllSystems (system: pkgs: pkgsHaskell: {
+    packages = forAllSystems (system: pkgs: pkgsHaskell:
+      let
+        src = builtins.path {
+          path = ./.;
+          name = "src";
+          filter = path: _: ! l.elem (l.baseNameOf path) ["flake.nix" "flake.lock"];
+        };
+      in {
 
       cabal2json =
         let
@@ -61,6 +68,7 @@
           };
           cabal2json = cabal2json''.overrideAttrs (old: {
             doCheck = false;
+            inherit src;
           });
         in
           cabal2json;
@@ -68,11 +76,7 @@
       cabal2json-haskell-nix =
         let
           flake = (pkgsHaskell.haskell-nix.project' {
-            src = builtins.path {
-              path = ./.;
-              name = "src";
-              filter = path: _: ! l.elem (l.baseNameOf path) ["flake.nix" "flake.lock"];
-            };
+            inherit src;
           }).flake {};
         in
           flake.packages."cabal2json:exe:cabal2json";

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixpkgs,
   } @ inp: let
     l = nixpkgs.lib // builtins;
-    supportedSystems = ["x86_64-linux"];
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
     forAllSystems = f: l.genAttrs supportedSystems
       (system: f system nixpkgs.legacyPackages.x86_64-linux


### PR DESCRIPTION
This PR adds `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin` to the supported systems.

It also contains a commit to ignore `flake.{nix,lock}` for the `cabal2json` package, same as the `cabal2json-haskell-nix` package did before.

Btw, what is that `cabal2json-haskell-nix` package? Is that just an alternative way to build the program?

Thanks for working on this, btw!